### PR TITLE
Pin untrusted PR build job token to contents: read

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # Runs untrusted PR code on pull_request_target; keep the token read-only.
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
The build job runs on `pull_request_target` and checks out untrusted PR head code (`npm ci`, `npm run build`), but its `GITHUB_TOKEN` was not restricted, so it inherited the org default of write. Pin it to `contents: read` (all the build job does is checkout, install, build, upload an artifact). No secrets were exposed here (those stay in the separate deploy job), this just removes the write-scoped token from the untrusted job.
