### PR TITLE
Fix: Use the new config repo directory structure

### DIFF
--- a/src/components/TargetListItem.svelte
+++ b/src/components/TargetListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Icon } from "@steeze-ui/svelte-icon"
 	import { Github, Check } from "@steeze-ui/lucide-icons"
-	import { Dialog, Tooltip } from "bits-ui"
+	import { Tooltip } from "bits-ui"
 	import type { CBTarget } from "$lib/cloudBuildTypes"
 
 	interface Props {
@@ -45,7 +45,7 @@
 	</div>
 	<div class="flex shrink-0">
 		<a
-			href={`https://github.com/betaflight/config/blob/master/configs/${target.target}/config.h`}
+			href={`https://github.com/betaflight/config/blob/master/configs/${target.manufacturerId}/${target.target}/config.h`}
 			target="_blank"
 			rel="noopener noreferrer"
 			class="hover:text-primary-500 w-fit h-fit bg-transparent hover:bg-primary-500/10 aspect-square p-1 rounded-lg"

--- a/src/routes/[key]/+page.svelte
+++ b/src/routes/[key]/+page.svelte
@@ -131,7 +131,7 @@
 											<span>View Target</span>
 										</a>
 										<a
-											href={`https://github.com/betaflight/config/blob/master/configs/${config.target}/config.h`}
+											href={`https://github.com/betaflight/config/blob/master/configs/${config.manufacturer}/${config.target}/config.h`}
 											class="btn preset-filled-primary-500 btn-sm"
 										>
 											<span><Icon src={Github} size="1rem" /></span>

--- a/src/routes/api/target/[target]/+server.ts
+++ b/src/routes/api/target/[target]/+server.ts
@@ -5,11 +5,16 @@ import type { RequestHandler } from "./$types"
 
 const octokit = new Octokit(env.GITHUB_PAT ? { auth: env.GITHUB_PAT } : {})
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, url }) => {
 	const { target } = params
+	const manufacturer = url.searchParams.get("manufacturer")
 
 	if (!target) {
 		return json({ error: "Target parameter is required" }, { status: 400 })
+	}
+
+	if (!manufacturer) {
+		return json({ error: "Manufacturer parameter is required" }, { status: 400 })
 	}
 
 	try {
@@ -19,7 +24,7 @@ export const GET: RequestHandler = async ({ params }) => {
 			{
 				owner: "betaflight",
 				repo: "config",
-				path: `configs/${target}/config.h`
+				path: `configs/${manufacturer}/${target}/config.h`
 			}
 		)
 
@@ -36,16 +41,17 @@ export const GET: RequestHandler = async ({ params }) => {
 
 		return json({
 			target,
+			manufacturer,
 			content,
 			url: configFile.html_url,
 			sha: configFile.sha,
 			size: configFile.size
 		})
-	} catch (error: any) {
+	} catch (error: unknown) {
 		console.error(`Error fetching config for target ${target}:`, error)
 
 		// Check if it's a 404 error (target not found)
-		if (error.status === 404) {
+		if (typeof error === "object" && error !== null && "status" in error && error.status === 404) {
 			return json({ error: `Target "${target}" not found` }, { status: 404 })
 		}
 

--- a/src/routes/targets/[target]/+page.svelte
+++ b/src/routes/targets/[target]/+page.svelte
@@ -52,10 +52,7 @@
 				<span class="w-fit text-surface-300 -ml-1">{manufacturer.name}</span>
 			{/if}
 		</div>
-		<a
-			href={`https://github.com/betaflight/config/blob/master/configs/${targetName}/config.h`}
-			class="btn preset-filled-primary-500"
-		>
+		<a href={target.url} class="btn preset-filled-primary-500">
 			Open in GitHub
 			<Icon src={Github} size="1.5rem" />
 		</a>

--- a/src/routes/targets/[target]/+page.ts
+++ b/src/routes/targets/[target]/+page.ts
@@ -21,14 +21,16 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		throw error(404, "This target only has legacy unified configs and no config.h file")
 	}
 
-	const response = await fetch(`/api/target/${target}`)
+	const manufacturerId = cloudBuildTarget.manufacturer
+	const response = await fetch(
+		`/api/target/${encodeURIComponent(target)}?manufacturer=${encodeURIComponent(manufacturerId)}`
+	)
 	const config = await response.json()
 
 	if (!response.ok) {
 		throw error(response.status, config.error || "Failed to fetch target config")
 	}
 
-	const manufacturerId = config.content.match(/MANUFACTURER_ID\s+(\w+)/)?.[1] ?? "UNKNOWN"
 	const manufacturerResponse = await fetch(
 		`https://build.betaflight.com/api/manufacturers/${manufacturerId}`
 	)


### PR DESCRIPTION
The config repo structure was changed in https://github.com/betaflight/config/pull/1164. This PR updates the fetching logic to correctly get specific targets given this new structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected links to firmware configuration files so they open the appropriate manufacturer-specific location on GitHub.
  * Improved target configuration loading by explicitly using the selected manufacturer.
  * Added clearer error handling when configuration details cannot be retrieved.
  * “Open in GitHub” now uses the verified configuration link provided by the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->